### PR TITLE
Add id, ko, nb to fix #25

### DIFF
--- a/src/options/options.html
+++ b/src/options/options.html
@@ -30,11 +30,14 @@
         <option value="fr">Français</option>
         <option value="fi">Suomi</option>
         <option value="hu">Magyar nyelv</option>
+        <option value="id">Bahasa Indonesia</option>
         <option value="it">Italiano</option>
         <option value="ja">日本語 (Japanese)</option>
+        <option value="ko">한국어 (Korean)</option>
         <option value="lv">Latviešu valoda</option>
         <option value="lt">Lietuvių kalba</option>
         <option value="nl">Nederlands</option>
+        <option value="nb">Norsk bokmål</option>
         <option value="pl">Polski</option>
         <option value="pt-PT">Português</option>
         <option value="pt-BR">Português (Brasil)</option>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -10,7 +10,7 @@ function renderOptions() {
 
 document.getElementById('defaultLang').addEventListener('click', (e) => {
   console.log(e.target.value);
-  if (['en', 'bg', 'cs', 'da', 'de', 'es', 'et', 'el', 'fr', 'fi', 'hu', 'it', 'ja', 'lv', 'lt', 'nl', 'pl', 'pt-PT', 'pt-BR', 'ro', 'ru', 'sk', 'sl', 'sv', 'tr', 'uk', 'zh'].indexOf(e.target.value) !== -1) {
+  if (['en', 'bg', 'cs', 'da', 'de', 'es', 'et', 'el', 'fr', 'fi', 'hu', 'it', 'id', 'ja', 'ko', 'lv', 'lt', 'nl', 'nb', 'pl', 'pt-PT', 'pt-BR', 'ro', 'ru', 'sk', 'sl', 'sv', 'tr', 'uk', 'zh'].indexOf(e.target.value) !== -1) {
     browser.storage.local.set({
       defaultLang: e.target.value
     });


### PR DESCRIPTION
This PR adds Indonesian, Korean and Norwegian languages. 

Note: the added languages are not yet listed under _target\_lang_ on the [DeepL API documentation](https://www.deepl.com/docs-api/translate-text/translate-text/).